### PR TITLE
Allow wrap-rpc to pass request to defremote

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ the genesis of shoreleave-remote.)
 (defremote remote-fn [arg1 arg2 ...] ...)
 ```
 
+To extract information, like session data, from the current request:
+
+```clojure
+(ns ...
+  (:require [cemerick.shoreleave.rpc :refer [defremote current-request]]))
+
+(defremote remote-fn [arg1 arg2 ...] 
+  (let [req (current-request)]
+    ...))
+```
+
 ### 2. Mix in the `wrap-rpc` middleware (still server-side, still Clojure)
 
 With bare Ring:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject shoreleave/shoreleave-remote-ring "0.3.0"
+(defproject shoreleave/shoreleave-remote-ring "0.3.1-SNAPSHOT"
   :description "A smarter client-side with ClojureScript : Ring- (and Compojure-) server-side Remotes support"
   :url "https://github.com/shoreleave/shoreleave-remote-ring"
   :license {:name "Eclipse Public License - v 1.0"

--- a/src/shoreleave/middleware/rpc.clj
+++ b/src/shoreleave/middleware/rpc.clj
@@ -60,9 +60,19 @@ metadata to the function name, e.g.:
     {:status 404
      :body "Remote not found."}))
 
+(def ^{:dynamic true
+       :doc "Reference to current request, accessible in defremote through current-request"}
+  *request* nil)
+
+(defn current-request
+  "Retrieve current request, providing access from defremote."
+  []
+  *request*)
+
 (defn handle-rpc
   [{{:keys [params remote]} :params :as request}]
-  (call-remote (keyword remote) (safe-read params)))
+  (binding [*request* request]
+    (call-remote (keyword remote) (safe-read params))))
 
 (defn wrap-rpc
   "Top-level Ring middleware to enable Shoreleave RPC calls"


### PR DESCRIPTION
This is an update of #3 for the new shoreleave namespace. Provides a `current-request` target used to retrieve request information from inside `defremote`.
