### PR TITLE
Update project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
             :distribution :repo
             :comments "See the notice in README.mkd or details in LICENSE_epl.html"}
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [org.clojure/tools.reader "0.7.0"]]
+                 [org.clojure/tools.reader "0.7.10"]]
   :dev-dependencies [;[cdt "1.2.6.2-SNAPSHOT"]
                      ;[lein-cdt "1.0.0"] ; use lein cdt to attach
                      ;[lein-autodoc "0.9.0"]


### PR DESCRIPTION
Update tools.reader to 0.7.10 to make shoreleave-remote-ring compatible with most recent cljs releases.
